### PR TITLE
Adiciona teste automatizado de erro de rede (issue #2)

### DIFF
--- a/__tests__/webhook.test.ts
+++ b/__tests__/webhook.test.ts
@@ -21,4 +21,24 @@ describe('Webhook MCP', () => {
     expect(response.status).toBe(200);
     expect(response.data.sucesso).toBe(true);
   });
+
+  it('deve lidar com erro de rede (mock)', async () => {
+    (axios as any).mockRejectedValue({
+      code: 'ECONNABORTED',
+      message: 'timeout',
+    });
+
+    try {
+      await axios({
+        method: 'POST',
+        url: 'https://exemplo.com/webhook',
+        data: { nome: 'Teste' },
+        timeout: 1,
+      });
+      // Se não lançar erro, falha o teste
+      fail('Deveria lançar erro de timeout');
+    } catch (error: any) {
+      expect(error.code).toBe('ECONNABORTED');
+    }
+  });
 }); 


### PR DESCRIPTION
Adiciona um teste unitário para simular erro de rede (timeout) e garantir cobertura mínima de testes automatizados, conforme solicitado na issue #2.