### PR TITLE
Adiciona Dockerfile para facilitar deploy (issue #8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 # Dockerfile para Webhooks MCP
-FROM node:20-alpine AS build
+FROM node:20-alpine
+
 WORKDIR /app
+
 COPY package*.json ./
-RUN npm install --legacy-peer-deps
+RUN npm install --production
+
 COPY . .
 RUN npm run build
 
-FROM node:20-alpine
-WORKDIR /app
-COPY --from=build /app/dist ./dist
-COPY package*.json ./
-RUN npm install --production --legacy-peer-deps
 CMD ["node", "dist/index.js"] 


### PR DESCRIPTION
Adiciona um Dockerfile para facilitar o deploy do MCP, conforme solicitado na issue #8. Instruções de uso já estão presentes no README.